### PR TITLE
WIP: Update to run in Python 3.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
 .*.swp
 .DS_Store
+.venv
+.vscode

--- a/anthonys-patch-for-mingus-0.4.3.0.diff
+++ b/anthonys-patch-for-mingus-0.4.3.0.diff
@@ -141,7 +141,7 @@ index c54d5f2..e7f83d8 100644
      def __init__(self):
          Instrument.__init__(self)
 diff --git a/mingus/containers/Note.py b/mingus/containers/Note.py
-index d76e86e..370fbf5 100644
+index d76e86e..a0b0549 100644
 --- a/mingus/containers/Note.py
 +++ b/mingus/containers/Note.py
 @@ -173,6 +173,7 @@ octave."""
@@ -152,6 +152,20 @@ index d76e86e..370fbf5 100644
  
      def from_int(self, integer):
          """Sets the Note corresponding to the integer. 0 is a C on octave 0, 12 is \
+@@ -321,6 +322,13 @@ False
+         else:
+             return 0
+ 
++    def __eq__(self, other): return self.__cmp__(other) == 0
++    def __ne__(self, other): return self.__cmp__(other) != 0
++    def __lt__(self, other): return self.__cmp__(other) < 0
++    def __le__(self, other): return self.__cmp__(other) <= 0
++    def __gt__(self, other): return self.__cmp__(other) > 0
++    def __ge__(self, other): return self.__cmp__(other) >= 0
++
+     def __repr__(self):
+         """A helpful representation for printing Note classes"""
+ 
 diff --git a/mingus/core/intervals.py b/mingus/core/intervals.py
 index 7803047..2bf3fbb 100644
 --- a/mingus/core/intervals.py
@@ -556,3 +570,18 @@ index 2f5d054..53e3569 100644
          l = self.int_to_varbyte(len(name))
          return '\x00' + META_EVENT + TRACK_NAME + l + name
  
+diff --git a/mingus/midi/__init__.py b/mingus/midi/__init__.py
+index c843d4d..7bbffc2 100644
+--- a/mingus/midi/__init__.py
++++ b/mingus/midi/__init__.py
+@@ -23,8 +23,8 @@
+ ================================================================================
+ """
+ 
+-from Sequencer import Sequencer
+-from SequencerObserver import SequencerObserver
++from mingus.midi.Sequencer import Sequencer
++from mingus.midi.SequencerObserver import SequencerObserver
+ __all__ = [
+     'Sequencer',
+     'SequencerObserver',

--- a/counterpoint.py
+++ b/counterpoint.py
@@ -95,8 +95,8 @@ def main():
         composition, errors = setup_midi(options.input_midi_file)
 
     if errors:
-        print >> sys.stderr, '%s: ERROR(S) ENCOUNTERED WHEN READING MUSIC:' % sys.argv[0]
-        print >> sys.stderr, '\n'.join(errors)
+        print('%s: ERROR(S) ENCOUNTERED WHEN READING MUSIC:' % sys.argv[0], file=sys.stderr)
+        print('\n'.join(errors), file=sys.stderr)
         sys.exit(1)
     elif composition is None:
         parser.error('Insufficient arguments provided. Use the -h argument to display help.')
@@ -111,11 +111,11 @@ def main():
 
     # Print out the standardized errors, and their corresponding rules.
     for error in errors:
-        print get_error_text(error)
+        print(get_error_text(error))
         rule = error[-1]
         if rule in written_rules:
-            print "Rule:", written_rules[rule]
-        print ""
+            print("Rule:", written_rules[rule])
+        print("")
 
 
     if options.png_file:

--- a/rules.py
+++ b/rules.py
@@ -98,7 +98,7 @@ def voice_crossing(b_list, a_list, note_spacing=2, note_filter_fn=None):
     def f_v_c(c_list, d_list, comparator):
         c_notes = [c for c in c_list]
         if callable(note_filter_fn):
-            c_notes = filter(note_filter_fn, c_notes)
+            c_notes = list(filter(note_filter_fn, c_notes))
         d_notes = [d_list.get_note_playing_at(c.bar, c.beat) for c in c_notes]
 
         for x in range(0, note_spacing):

--- a/structures.py
+++ b/structures.py
@@ -3,22 +3,22 @@ from mingus.containers import Note, NoteContainer, Bar, Composition, Instrument,
 
 # Set up our vocal classes
 class Soprano(Instrument):
-    name = u'Soprano'
+    name = 'Soprano'
     range = (Note('C', 4), Note('C', 6))
     clef = 'treble'
 
 class Alto(Instrument):
-    name = u'Alto'
+    name = 'Alto'
     range = (Note('F', 3), Note('F', 5))
     clef = 'treble'
 
 class Tenor(Instrument):
-    name = u'Tenor'
+    name = 'Tenor'
     range = (Note('C', 3), Note('C', 5))
     clef = 'tenor'
 
 class Bass(Instrument):
-    name = u'Bass'
+    name = 'Bass'
     range = (Note('E', 2), Note('E', 4))
     clef = 'bass'
 

--- a/views.py
+++ b/views.py
@@ -80,7 +80,7 @@ def vertical_intervals(a_list, b_list):
         for bar, beat in changes
     ]
 
-    return zip(intervals, changes)
+    return list(zip(intervals, changes))
 
 def directions(a_list):
     """
@@ -324,7 +324,7 @@ def parallel_motion(a_list, b_list, filter_fn=None):
     pairs = vertical_intervals(a_list, b_list)
 
     if callable(filter_fn):
-        pairs = filter(filter_fn, pairs)
+        pairs = list(filter(filter_fn, pairs))
 
     consecutives = []
     prev = ('0', None)

--- a/views.py
+++ b/views.py
@@ -17,7 +17,7 @@ def get_interval(note_a, note_b):
         octave = 0
     else:
         name = mintervals.determine(note_a, note_b, True)
-        octave = abs(int(note_a) - int(note_b))/12
+        octave = abs(int(note_a) - int(note_b))//12
     return (name, octave)
 
 def get_semitones(interval_tuplet):
@@ -26,22 +26,6 @@ def get_semitones(interval_tuplet):
     Returns an int representing the semitones within the interval.
     """
     return mintervals.semitones_from_shorthand(interval_tuplet[0]) + 12*interval_tuplet[1]
-
-def compare_times(time_a, time_b):
-    """
-    Takes two time tuples of the form:
-        (int: bar #, float: beat #)
-
-    Returns:
-        -1 if time_a is before time_b
-         0 if they represent the same time
-         1 if time_a is after time_b
-    """
-    bar_cmp = cmp(time_a[0], time_b[0])
-    if bar_cmp != 0:
-        return bar_cmp
-    else:
-        return cmp(time_a[1], time_b[1])
 
 def note_onsets(a_list, b_list):
     """
@@ -109,7 +93,7 @@ def directions(a_list):
         elif note.prev_actual_note is None:
             direction = 0
         else:
-            direction = cmp(int(note), int(note.prev_actual_note))
+            direction = note.__cmp__(note.prev_actual_note)
         return direction
 
     directions = []
@@ -256,7 +240,7 @@ def indirect_horizontal_intervals(a_list):
     # can be assured that no two consecutive extremities will be of the same
     # type, as maxima and minima must alternate.
     extremities = maxima + minima
-    extremities.sort(compare_times)
+    extremities.sort()
 
     # Generate tuples for all neighbouring maxima/minima
     onset_pairs = [
@@ -264,6 +248,8 @@ def indirect_horizontal_intervals(a_list):
         for i,x in enumerate(extremities)
         if (i+1) < len(extremities)
     ]
+
+    x = extremities[-1]
 
     # Find the actual note objects for each pair of onsets
     note_pairs = [

--- a/views.py
+++ b/views.py
@@ -249,11 +249,9 @@ def indirect_horizontal_intervals(a_list):
         if (i+1) < len(extremities)
     ]
 
-    x = extremities[-1]
-
     # Find the actual note objects for each pair of onsets
     note_pairs = [
-        (a_list.get(*x), a_list.get(*b))
+        (a_list.get(*a), a_list.get(*b))
         for a, b in onset_pairs
     ]
 


### PR DESCRIPTION
This is the smallest possible PR to make counterpoint.py run in Python 3.9.

This PR doesn't upgrade Mingus beyond it's 10 year old 0.4.3.0 release, but it does include a patch for that release to implement Python 3.9 compatibility.

A better solution would be to update the library to use Mingus 0.6.0 which was released in 2020 and supports Python 3, or to port it to use Music21 instead.